### PR TITLE
Fix for Ubuntu systems

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -6,7 +6,7 @@
             'libvirt0',
             'qemu-kvm',
         ],
-        'service': 'libvirtd',
+        'service': 'libvirt-bin',
     },
     'RedHat': {
         'pkgs': [


### PR DESCRIPTION
The formula fails on Ubuntu systems since the daemon is not libvirtd, but libvirt-bin. This is corrected in the map.jinja file and tested on my local system.
