### PR TITLE
missing libvirt-bin from debian deps

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -5,6 +5,7 @@
             'libguestfs-tools',
             'libvirt0',
             'qemu-kvm',
+            'libvirt-bin',
         ],
         'service': 'libvirt-bin',
     },


### PR DESCRIPTION
There's a missing package  (libvirt-bin) in the debian list and without it the service is not created and the state fails .
