### PR TITLE
fixed different daemon name since debian 8 (jessie)

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -8,7 +8,7 @@
             'libvirt-bin',
             'python-libvirt',
         ],
-        'service': 'libvirt-bin',
+        'service': 'libvirt-bin' if grains['osmajorrelease']|float < 8 else 'libvirtd',
     },
     'RedHat': {
         'pkgs': [


### PR DESCRIPTION
The name of the daemon since Debian 8 (jessie) is libvirtd and no more libvirt-bin.