### PR TITLE
Less fragile service-name detection.

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -8,7 +8,7 @@
             'libvirt-bin',
             'python-libvirt',
         ],
-        'service': 'libvirt-bin' if grains['osmajorrelease']|float < 8 else 'libvirtd',
+        'service': 'libvirtd' if grains.get('osmajorrelease', 0)|float >= 8 else 'libvirt-bin',
     },
     'RedHat': {
         'pkgs': [


### PR DESCRIPTION
Service name check on debian-family systems now gracefully handles a missing osmajorrelease grain, as is the case on the current Ubuntu LTS.

I chose to do it this way rather than explicitly checking Ubuntu OS because the map is looking at os_family, not os, and changing that would involve much pain.

Closes #8