### PR TITLE
remove libguestfs from Arch

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -21,7 +21,6 @@
     },
     'Arch': {
         'pkgs': [
-            'libguestfs',
             'libvirt',
             'qemu',
             'libvirt-python',


### PR DESCRIPTION
remove libguestfs as it is not provided by the official repositories.
libguestfs has to be built manually as it is now in AUR:
https://aur.archlinux.org/packages/libguestfs/