### PR TITLE
Fix a typo causing installation of unwanted qemu packages

### DIFF
--- a/libvirt/install.sls
+++ b/libvirt/install.sls
@@ -6,7 +6,7 @@ libvirt.pkg:
 
 qemu:
   pkg.installed:
-    - pkg: {{ libvirt_settings.qemu_pkg }}
+    - name: {{ libvirt_settings.qemu_pkg }}
 
 extra_pkgs:
   pkg.installed:


### PR DESCRIPTION
After upgrading my formula clone, my Debian installation started pulling qemu-system-* and a plethora of X related packages which are unwanted since I only need qemu-kvm. Looks like the problem came from this `pkg.installed: pkg`. For some reason it works while it is not described in the documentation of the state. `name` or `pkgs` should be the valid forms. Anyway given previous commits, it looks like only one package is desired here hence using `name` should be appropriate.