### PR TITLE
Fixed branch comparison

### DIFF
--- a/libvirt/keys.sls
+++ b/libvirt/keys.sls
@@ -1,4 +1,4 @@
-{%- set salt_version = salt['grains.get']('saltversion', '') %}
+{%- set salt_version = salt['grains.get']('saltversioninfo', '') %}
 include:
   - .config
 

--- a/libvirt/keys.sls
+++ b/libvirt/keys.sls
@@ -1,13 +1,16 @@
+{%- set salt_version = salt['grains.get']('saltversion', '') %}
 include:
   - .config
 
 libvirt.keys:
 # API changes with version 2016.3.0
-{% if salt['grains.get']('saltversion', '') < '2016.3.0' %}
+{%- if salt_version[0]|int < 2016 %}
   libvirt.keys:
-{% else %}
+{%- elif salt_version[1]|int <= 3 %}
+  libvirt.keys:
+{%- else %}
   virt.keys:
-{% endif %}
+{%- endif %}
     - name: libvirt_keys
     - require:
       - pkg: libvirt.pkg


### PR DESCRIPTION
Please note that:
`
>>> '2016.3.0' < '2016.11.0'
False
>>> '2016.3.0' > '2016.11.0'
True
>>> '3' > '11'
True
>>> 3 > 11
False
`

Therefore I just fixed the comparison using saltversioninfo and doing a comparison considering major and minor numbering as wall as using integer comparison.