### PR TITLE
Add support for multiple distribution releases

### DIFF
--- a/libvirt/codenamemap.yaml
+++ b/libvirt/codenamemap.yaml
@@ -1,2 +1,14 @@
+# Debian
 squeeze:
+  libvirt_pkg: libvirt-bin
+  libvirt_service: libvirt-bin
+jessie:
+  libvirt_pkg: libvirt-bin
+  libvirt_service: libvirtd
+# Ubuntu
+trusty:
+  libvirt_pkg: libvirt-bin
+  libvirt_service: libvirt-bin
+xenial:
+  libvirt_pkg: libvirt-bin
   libvirt_service: libvirt-bin

--- a/libvirt/codenamemap.yaml
+++ b/libvirt/codenamemap.yaml
@@ -1,0 +1,2 @@
+squeeze:
+  libvirt_service: libvirt-bin

--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -1,30 +1,26 @@
 {## start with defaults from defaults.yaml ##}
 {% import_yaml "libvirt/defaults.yaml" as default_settings %}
+{% import_yaml "libvirt/osmap.yaml" as osmap %}
+{% import_yaml "libvirt/codenamemap.yaml" as codenamemap %}
 
 {##
 Setup variables using grain['os_family'] based logic, only add key:values here
 that differ from whats in defaults.yaml
 ##}
-{% set os_family_map = salt['grains.filter_by']({
-    'Debian': {
-      'libvirt_pkg': 'libvirt-bin',
-      'libvirt_service': 'libvirtd' if grains.get('osmajorrelease', 0)|float >= 8 else 'libvirt-bin',
-      'qemu_pkg': 'qemu-kvm',
-      'python_pkg': 'python-libvirt',
-      'extra_pkgs': ['libguestfs0', 'libguestfs-tools', 'gnutls-bin', 'virt-top'],
-      'daemon_config_path': '/etc/default',
-    },
-    'RedHat': {
-      'qemu_pkg': 'qemu-kvm',
-      'extra_pkgs': ['libguestfs'],
-      'daemon_config_path': '/etc/sysconfig',
-    },
-    'Arch': {
-      'daemon_config_path': '/etc/conf.d',
-    },
-  }, grain="os_family", merge=salt['pillar.get']('libvirt:lookup'))
-%}
-  
-{% do default_settings.libvirt.update(os_family_map) %}
+{% set os_family_map = salt['grains.filter_by'](osmap, grain='os_family') or {} %}
+{# get the settings for the oscodename grain, os_family data will override
+    oscodename data #}
+{% set os_codename = salt['grains.filter_by'](codenamemap,
+                                              grain='oscodename',
+                                              merge=os_family_map) or {} %}
 
-{% set libvirt_settings = salt['pillar.get']('libvirt', default=default_settings.libvirt, merge=True) %}
+{# merge the os family/codename specific data over the defaults #}
+{% do default_settings.libvirt.update(os_codename) %}
+
+{# merge the pillar:lookup dict into the defaults/os specific dict #}
+{% set lookup = salt['pillar.get']('libvirt:lookup',
+                                   default=default_settings.libvirt,
+                                   merge=True) %}
+
+{# merge the actual libvirt pillar into the above combined dict #}
+{% set libvirt_settings = salt['pillar.get']('libvirt', default=lookup, merge=True) %}

--- a/libvirt/osmap.yaml
+++ b/libvirt/osmap.yaml
@@ -1,0 +1,18 @@
+Arch:
+  daemon_config_path: /etc/conf.d
+Debian:
+  libvirt_pkg: libvirt-bin
+  libvirt_service: libvirtd
+  qemu_pkg: qemu-kvm
+  python_pkg: python-libvirt
+  extra_pkgs:
+    - libguestfs0
+    - libguestfs-tools
+    - gnutls-bin
+    - virt-top
+  daemon_config_path: /etc/default
+RedHat:
+  qemu_pkg: qemu-kvm
+  extra_pkgs:
+    - libguestfs
+  daemon_config_path: /etc/sysconfig

--- a/libvirt/osmap.yaml
+++ b/libvirt/osmap.yaml
@@ -1,7 +1,7 @@
 Arch:
   daemon_config_path: /etc/conf.d
 Debian:
-  libvirt_pkg: libvirt-bin
+  libvirt_pkg: libvirt-daemon-system
   libvirt_service: libvirtd
   qemu_pkg: qemu-kvm
   python_pkg: python-libvirt


### PR DESCRIPTION
The need emerged from switching systems to Debian Stretch however I took the generic approach used by
saltstack-formulas/postgres-formula.

The state was tested on Debian Jessie and Stretch and file and packages names were checked for Ubuntu LTS releases as well.