### PR TITLE
fix(keys): “virt.keys” requires the python library

### DIFF
--- a/libvirt/keys.sls
+++ b/libvirt/keys.sls
@@ -1,5 +1,6 @@
 {%- set salt_version = salt['grains.get']('saltversioninfo', '') %}
 include:
+  - .python
   - .config
 
 libvirt.keys:
@@ -12,3 +13,4 @@ libvirt.keys:
     - name: libvirt_keys
     - require:
       - pkg: libvirt.pkg
+      - pkg: libvirt-python


### PR DESCRIPTION
* libvirt/keys.sls: add a dependency on the python package