### PR TITLE
fix(packages): Python2 libvirt library is unusable by Python3 minion

### DIFF
--- a/libvirt/defaults.yaml
+++ b/libvirt/defaults.yaml
@@ -1,7 +1,8 @@
 libvirt:
   libvirt_pkg: libvirt
   qemu_pkg: qemu
-  python_pkg: libvirt-python
+  python2_pkg: python-libvirt
+  python3_pkg: python3-libvirt
   libvirt_service: libvirtd
   libvirtd_config: /etc/libvirt/libvirtd.conf
   daemon_config_path: {}

--- a/libvirt/keys.sls
+++ b/libvirt/keys.sls
@@ -1,4 +1,11 @@
+{%- from "libvirt/map.jinja" import libvirt_settings with context %}
+{%- from "libvirt/python.jinja" import switch_python32 with context %}
+
+{%- set package = switch_python32(libvirt_settings.python3_pkg, libvirt_settings.python2_pkg) %}
 {%- set salt_version = salt['grains.get']('saltversioninfo', '') %}
+
+{#- Some OS do not have the python3 library #}
+{%- if package %}
 include:
   - .python
   - .config
@@ -14,3 +21,4 @@ libvirt.keys:
     - require:
       - pkg: libvirt.pkg
       - pkg: libvirt-python
+{%- endif %}

--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -1,26 +1,44 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
 {## start with defaults from defaults.yaml ##}
-{% import_yaml "libvirt/defaults.yaml" as default_settings %}
-{% import_yaml "libvirt/osmap.yaml" as osmap %}
-{% import_yaml "libvirt/codenamemap.yaml" as codenamemap %}
+{%- import_yaml tplroot ~ "/defaults.yaml" as default_settings %}
+{%- import_yaml tplroot ~ "/osfamilymap.yaml" as osfamilymap %}
+{%- import_yaml tplroot ~ "/osmap.yaml" as osmap %}
+{%- import_yaml tplroot ~ "/osfingermap.yaml" as osfingermap %}
 
-{##
-Setup variables using grain['os_family'] based logic, only add key:values here
-that differ from whats in defaults.yaml
-##}
-{% set os_family_map = salt['grains.filter_by'](osmap, grain='os_family') or {} %}
-{# get the settings for the oscodename grain, os_family data will override
-    oscodename data #}
-{% set os_codename = salt['grains.filter_by'](codenamemap,
-                                              grain='oscodename',
-                                              merge=os_family_map) or {} %}
+{#- Retrieve the config dict only once #}
+{%- set _config = salt['config.get'](tplroot, default={}) %}
 
-{# merge the os family/codename specific data over the defaults #}
-{% do default_settings.libvirt.update(os_codename) %}
+{%- set defaults = salt['grains.filter_by'](
+      default_settings,
+      default=tplroot,
+      merge=salt['grains.filter_by'](
+        osfamilymap,
+        grain='os_family',
+        merge=salt['grains.filter_by'](
+          osmap,
+          grain='os',
+          merge=salt['grains.filter_by'](
+            osfingermap,
+            grain='osfinger',
+            merge=salt['grains.filter_by'](
+              _config,
+              default='lookup'
+            )
+          )
+        )
+      )
+    )
+ %}
 
-{# merge the pillar:lookup dict into the defaults/os specific dict #}
-{% set lookup = salt['pillar.get']('libvirt:lookup',
-                                   default=default_settings.libvirt,
-                                   merge=True) %}
+{%- set config = salt['grains.filter_by'](
+      {'defaults': defaults},
+      default='defaults',
+      merge=_config
+    )
+%}
 
-{# merge the actual libvirt pillar into the above combined dict #}
-{% set libvirt_settings = salt['pillar.get']('libvirt', default=lookup, merge=True) %}
+{%- set libvirt_settings = config %}

--- a/libvirt/osfamilymap.yaml
+++ b/libvirt/osfamilymap.yaml
@@ -1,0 +1,25 @@
+Arch:
+  daemon_config_path: /etc/conf.d
+  python2_pkg: libvirt-python
+  python3_pkg: libvirt-python3
+Debian:
+  libvirt_pkg: libvirt-daemon-system
+  libvirt_service: libvirtd
+  qemu_pkg: qemu-kvm
+  extra_pkgs:
+    - libguestfs0
+    - libguestfs-tools
+    - gnutls-bin
+    - virt-top
+  daemon_config_path: /etc/default
+RedHat:
+  qemu_pkg: qemu-kvm
+  python2_pkg: libvirt-python
+  python3_pkg: libvirt-python3
+  extra_pkgs:
+    - libguestfs
+  daemon_config_path: /etc/sysconfig
+Suse:
+  python2_pkg: python2-libvirt-python
+  python3_pkg: python3-libvirt-python
+  daemon_config_path: /etc/sysconfig

--- a/libvirt/osfingermap.yaml
+++ b/libvirt/osfingermap.yaml
@@ -1,17 +1,32 @@
-# Debian
-squeeze:
+## Debian
+# Squeeze
+Debian-6:
   libvirt_pkg: libvirt-bin
   libvirt_service: libvirt-bin
-jessie:
+# Jessie
+Debian-8:
   libvirt_pkg: libvirt-bin
   libvirt_service: libvirtd
-stretch:
+# Stretch
+Debian-9:
   libvirt_pkg: libvirt-daemon
   libvirt_service: libvirtd
-# Ubuntu
-trusty:
+
+## Ubuntu
+# Trusty
+Ubuntu-14.04:
   libvirt_pkg: libvirt-bin
   libvirt_service: libvirt-bin
-xenial:
+# Xenial
+Ubuntu-16.04:
   libvirt_pkg: libvirt-bin
   libvirt_service: libvirt-bin
+
+## Suse
+Leap-42:
+  python2_pkg: libvirt-python
+  python3_pkg: ''
+
+## Fedora
+Fedora-28:
+  python3_pkg: ''

--- a/libvirt/osmap.yaml
+++ b/libvirt/osmap.yaml
@@ -1,18 +1,5 @@
-Arch:
-  daemon_config_path: /etc/conf.d
-Debian:
-  libvirt_pkg: libvirt-daemon-system
-  libvirt_service: libvirtd
-  qemu_pkg: qemu-kvm
-  python_pkg: python-libvirt
-  extra_pkgs:
-    - libguestfs0
-    - libguestfs-tools
-    - gnutls-bin
-    - virt-top
-  daemon_config_path: /etc/default
-RedHat:
-  qemu_pkg: qemu-kvm
-  extra_pkgs:
-    - libguestfs
-  daemon_config_path: /etc/sysconfig
+Fedora:
+  python2_pkg: python2-libvirt
+  python3_pkg: python3-libvirt
+CentOS:
+  python3_pkg: ''

--- a/libvirt/python.jinja
+++ b/libvirt/python.jinja
@@ -1,0 +1,34 @@
+{%- macro switch_python32(python3, python2) %}
+  {#-
+  Returns arguments depending on the Python environment of the
+  SaltStack minion.
+
+  A `none` argument is returned as an empty string `''`.
+
+  Params:
+    * python3: the parameter to return in case of a Python3 minion.
+    * python2: the parameter to return in case of a Python2 minion.
+
+  Example:
+
+    {%- set package = switch_python32('python3-library', 'python2-library') %}
+    {%- if package %}
+      pkg-install-{{ package }}:
+        pkg.installed:
+          - name: {{ package }}
+    {%- endif %}
+
+  The `package` will be `python3-library` when the SaltStack minion
+  runs under Python3 or `python2-library` otherwise.
+  #}
+  {%- if salt['grains.get']('pythonversion')[0] == 3 %}
+    {%- set selected = python3 %}
+  {%- else %}
+    {%- set selected = python2 %}
+  {%- endif %}
+  {#- Coerce null value to empty string to make tests simpler #}
+  {%- if not selected or selected is none -%}
+  {%- else -%}
+    {{ selected }}
+  {%- endif -%}
+{%- endmacro -%}

--- a/libvirt/python.sls
+++ b/libvirt/python.sls
@@ -1,5 +1,11 @@
-{% from "libvirt/map.jinja" import libvirt_settings with context %}
+{%- from "libvirt/map.jinja" import libvirt_settings with context %}
+{%- from "libvirt/python.jinja" import switch_python32 with context %}
 
+{%- set package = switch_python32(libvirt_settings.python3_pkg, libvirt_settings.python2_pkg) %}
+
+{#- Some OS do not have the python3 library #}
+{%- if package %}
 libvirt-python:
   pkg.installed:
-    - name: {{ libvirt_settings.python_pkg }}
+    - name: {{ package }}
+{%- endif %}


### PR DESCRIPTION
* libvirt/python.sls: mangle the package name when the minion is using Python3