### PR TITLE
fix(config): Suse family does not have it's own configuration file

### DIFF
--- a/libvirt/templates/Suse/daemon_libvirtd.jinja
+++ b/libvirt/templates/Suse/daemon_libvirtd.jinja
@@ -1,0 +1,35 @@
+# This file is managed by Salt, do not edit by Hand!!
+{% set cfg_libvirt = pillar.get('libvirt', {}) -%}
+{% set cfg_daemon_opts= cfg_libvirt.get('daemon_opts', {}) -%}
+{%- macro get_config(configname, default_value) -%}
+{%- if configname in cfg_daemon_opts -%}
+{{ configname }} = {{ cfg_daemon_opts[configname]|json }}
+{%- else -%}
+#{{ configname }} = {{ default_value|json }}
+{%- endif -%}
+{%- endmacro -%}
+
+# Override the default config file
+# NOTE: This setting is no longer honoured if using
+# systemd. Set '--config /etc/libvirt/libvirtd.conf'
+# in LIBVIRTD_ARGS instead.
+#LIBVIRTD_CONFIG=/etc/libvirt/libvirtd.conf
+
+# Listen for TCP/IP connections
+# NB. must setup TLS/SSL keys prior to using this
+{{ get_config('LIBVIRTD_ARGS', '{}') }}
+
+# Override Kerberos service keytab for SASL/GSSAPI
+#KRB5_KTNAME=/etc/libvirt/krb5.tab
+
+# Override the QEMU/SDL default audio driver probing when
+# starting virtual machines using SDL graphics
+#
+# NB these have no effect for VMs using VNC, unless vnc_allow_host_audio
+# is enabled in /etc/libvirt/qemu.conf
+#QEMU_AUDIO_DRV=sdl
+#
+#SDL_AUDIODRIVER=pulse
+
+# Override the maximum number of opened files
+#LIBVIRTD_NOFILES_LIMIT=2048


### PR DESCRIPTION
* libvirt/templates/Suse/daemon_libvirtd.jinja: use the same
  configuration file as RedHat.