### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -43,16 +43,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/libvirt/defaults.yaml
+++ b/libvirt/defaults.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 libvirt:
   libvirt_pkg: libvirt
   qemu_pkg: qemu
@@ -7,4 +10,3 @@ libvirt:
   libvirtd_config: /etc/libvirt/libvirtd.conf
   daemon_config_path: {}
   extra_pkgs: []
-  

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 libvirt:
-  #lookup:
-  # - override map.jinja and defaults.yml
-  #daemon_opts:
+  # lookup:
+  #   # override map.jinja and defaults.yaml
+  # daemon_opts:
   #  libvirtd_opts: '-d'
 
   libvirtd:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: libvirt formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
libvirt-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./libvirt/defaults.yaml
  1:1       warning  missing document start "---"  (document-start)
  10:1      error    trailing spaces  (trailing-spaces)

pillar.example
  1:1       warning  missing document start "---"  (document-start)
  2:4       warning  missing starting space in comment  (comments)
  4:4       warning  missing starting space in comment  (comments)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.