### PR TITLE
fix(packages): CentOS has no Python3 libvirt library

### DIFF
--- a/libvirt/osmap.yaml
+++ b/libvirt/osmap.yaml
@@ -13,3 +13,6 @@
 Fedora:
   python2_pkg: python2-libvirt
   python3_pkg: python3-libvirt
+
+CentOS:
+  python3_pkg: ~


### PR DESCRIPTION
----

#