### PR TITLE
feat(systemd): check sockets created by systemd

### DIFF
--- a/test/integration/default/controls/socket_admin_spec.rb
+++ b/test/integration/default/controls/socket_admin_spec.rb
@@ -10,8 +10,8 @@ control 'Libvirt admin socket' do
   describe libvirt_socket_admin do
     it { should exist }
     its('type') { should eq :socket }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0700' }
+    its('owner') { should eq libvirt_socket_admin.config_owner }
+    its('group') { should eq libvirt_socket_admin.config_group }
+    its('mode') { should cmp libvirt_socket_admin.config_mode }
   end
 end

--- a/test/integration/default/controls/socket_ro_spec.rb
+++ b/test/integration/default/controls/socket_ro_spec.rb
@@ -10,8 +10,8 @@ control 'Libvirt read only socket' do
   describe libvirt_socket_ro do
     it { should exist }
     its('type') { should eq :socket }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0777' }
+    its('owner') { should eq libvirt_socket_ro.config_owner }
+    its('group') { should eq libvirt_socket_ro.config_group }
+    its('mode') { should cmp libvirt_socket_ro.config_mode }
   end
 end

--- a/test/integration/default/controls/socket_rw_spec.rb
+++ b/test/integration/default/controls/socket_rw_spec.rb
@@ -10,8 +10,8 @@ control 'Libvirt read/write socket' do
   describe libvirt_socket_rw do
     it { should exist }
     its('type') { should eq :socket }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0770' }
+    its('owner') { should eq libvirt_socket_rw.config_owner }
+    its('group') { should eq libvirt_socket_rw.config_group }
+    its('mode') { should cmp libvirt_socket_rw.config_mode }
   end
 end

--- a/test/integration/share/libraries/libvirt_socket_admin.rb
+++ b/test/integration/share/libraries/libvirt_socket_admin.rb
@@ -15,6 +15,31 @@ class LibvirtSocketAdminResource < Inspec.resource(1)
 
   def initialize
     @file = inspec.file('/var/run/libvirt/libvirt-admin-sock')
+    @systemd_status = inspec.systemd_config('libvirtd-admin.socket')
+  end
+
+  def config_owner
+    if @systemd_status.active?
+      @systemd_status.config('SocketUser') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_group
+    if @systemd_status.active?
+      @systemd_status.config('SocketGroup') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_mode
+    if @systemd_status.active?
+      @systemd_status.config('SocketMode') || '0666'
+    else
+      '0700'
+    end
   end
 
   # We could not inherit from Inspec::Resources::FileResource

--- a/test/integration/share/libraries/libvirt_socket_ro.rb
+++ b/test/integration/share/libraries/libvirt_socket_ro.rb
@@ -15,6 +15,31 @@ class LibvirtSocketRoResource < Inspec.resource(1)
 
   def initialize
     @file = inspec.file('/var/run/libvirt/libvirt-sock-ro')
+    @systemd_status = inspec.systemd_config('libvirtd-ro.socket')
+  end
+
+  def config_owner
+    if @systemd_status.active?
+      @systemd_status.config('SocketUser') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_group
+    if @systemd_status.active?
+      @systemd_status.config('SocketGroup') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_mode
+    if @systemd_status.active?
+      @systemd_status.config('SocketMode') || '0666'
+    else
+      '0777'
+    end
   end
 
   # We could not inherit from Inspec::Resources::FileResource

--- a/test/integration/share/libraries/libvirt_socket_rw.rb
+++ b/test/integration/share/libraries/libvirt_socket_rw.rb
@@ -15,6 +15,31 @@ class LibvirtSocketRwResource < Inspec.resource(1)
 
   def initialize
     @file = inspec.file('/var/run/libvirt/libvirt-sock')
+    @systemd_status = inspec.systemd_config('libvirtd.socket')
+  end
+
+  def config_owner
+    if @systemd_status.active?
+      @systemd_status.config('SocketUser') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_group
+    if @systemd_status.active?
+      @systemd_status.config('SocketGroup') || 'root'
+    else
+      'root'
+    end
+  end
+
+  def config_mode
+    if @systemd_status.active?
+      @systemd_status.config('SocketMode') || '0666'
+    else
+      '0770'
+    end
   end
 
   # We could not inherit from Inspec::Resources::FileResource

--- a/test/integration/share/libraries/systemd_config.rb
+++ b/test/integration/share/libraries/systemd_config.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# systemd_config.rb -- InSpec resource for systemd service configuration
+# Author: Daniel Dehennin <daniel.dehennin@baby-gnu.org>
+# Copyright (C) 2020 Daniel Dehennin <daniel.dehennin@baby-gnu.org>
+
+class SystemdConfigResource < Inspec.resource(1)
+  name 'systemd_config'
+
+  supports platform_name: 'debian'
+  supports platform_name: 'ubuntu'
+  supports platform_name: 'centos'
+  supports platform_name: 'fedora'
+  supports platform_name: 'opensuse'
+
+  def initialize(service_name)
+    @service_name = service_name
+    @service_config = read_systemd_show
+  end
+
+  def enabled?
+    @service_config.send('UnitFileState') == 'enabled'
+  end
+
+  def active?
+    @service_config.send('ActiveState') == 'active'
+  end
+
+  def test
+    @service_config.methods
+  end
+
+  def config(param)
+    @service_config.send(param)
+  end
+
+  def read_systemd_show
+    cmd_string = "systemctl show #{@service_name}"
+    cmd = inspec.command(cmd_string)
+
+    unless cmd.exit_status.zero?
+      raise Inspec::Exceptions::ResourceSkipped,
+            "Error running '#{cmd_string}': #{cmd.stderr}"
+    end
+
+    parse_options = {
+      assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+    }
+    inspec.parse_config(cmd.stdout.strip, parse_options)
+  end
+end


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

- #64

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

On systems with sockets created by systemd, the configuration in
“libvirtd.conf” is not used.

* test/integration/share/libraries/systemd_config.rb: new utility to
  get systemd service configuration options.

* test/integration/share/libraries/libvirt_socket_admin.rb: load
  “libvirt-admin.socket” configuration and provide 3 methods to return
  owner, group and permissions defined. Fallback on default values.

* test/integration/share/libraries/libvirt_socket_ro.rb: load
  “libvirt-ro.socket” configuration and provide 3 methods to return
  owner, group and permissions defined. Fallback on default values.

* test/integration/share/libraries/libvirt_socket_rw.rb: load
  “libvirt.socket” configuration and provide 3 methods to return
  owner, group and permissions defined. Fallback on default values.

* test/integration/default/controls/socket_admin_spec.rb: check socket
  owner, group and permissions against configured values.

* test/integration/default/controls/socket_ro_spec.rb: ditoo.

* test/integration/default/controls/socket_rw_spec.rb: ditoo.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
-----> Starting Kitchen (v2.3.3)
-----> Verifying <default-fedora-31-master-py3>...
       Loaded default 

Profile: libvirt formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:32768

  ✔  Libvirt service: verify running service
     ✔  Service libvirtd should be enabled
     ✔  Service libvirtd should be running
  ✔  Libvirt packages: verify installed packages
     ✔  System Package libvirt should be installed
     ✔  System Package qemu-kvm should be installed
     ✔  System Package libguestfs should be installed
     ✔  System Package python3-libvirt should be installed
  ✔  Libvirt read/write socket: should exist with proper permissions
     ✔  libvirt_socket_rw should exist
     ✔  libvirt_socket_rw type should eq :socket
     ✔  libvirt_socket_rw owner should eq "root"
     ✔  libvirt_socket_rw group should eq "root"
     ✔  libvirt_socket_rw mode should cmp == "0666"
  ✔  Libvirt admin socket: should exist with proper permissions
     ✔  libvirt_socket_admin should exist
     ✔  libvirt_socket_admin type should eq :socket
     ✔  libvirt_socket_admin owner should eq "root"
     ✔  libvirt_socket_admin group should eq "root"
     ✔  libvirt_socket_admin mode should cmp == "0600"
  ✔  Libvirt configuration: verify applied configuration
     ✔  File /etc/sysconfig/libvirtd should exist
     ✔  File /etc/sysconfig/libvirtd content should match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  File /etc/libvirt/libvirtd.conf should exist
     ✔  File /etc/libvirt/libvirtd.conf content should match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tls should eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tcp should eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tls_port should eq "16514"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tcp_port should eq "16509"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_addr should eq "0.0.0.0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_group should eq "root"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_ro_perms should eq "0777"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_rw_perms should eq "0770"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_ro should eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_rw should eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_tcp should eq "none"
  ✔  Libvirt read only socket: should exist with proper permissions
     ✔  libvirt_socket_ro should exist
     ✔  libvirt_socket_ro type should eq :socket
     ✔  libvirt_socket_ro owner should eq "root"
     ✔  libvirt_socket_ro group should eq "root"
     ✔  libvirt_socket_ro mode should cmp == "0666"


Profile: libvirt formula (share)
Version: (not specified)
Target:  ssh://kitchen@localhost:32768

     No tests executed.

Profile Summary: 6 successful controls, 0 control failures, 0 controls skipped
Test Summary: 36 successful, 0 failures, 0 skipped
       Finished verifying <default-fedora-31-master-py3> (0m9.68s).
-----> Kitchen is finished. (0m12.62s)
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


