### PR TITLE
Feature/support centos 8

### DIFF
--- a/libvirt/osfingermap.yaml
+++ b/libvirt/osfingermap.yaml
@@ -30,3 +30,8 @@ Ubuntu-14.04:
 Ubuntu-16.04:
   libvirt_pkg: libvirt-bin
   libvirt_service: libvirt-bin
+
+## os: CentOS
+CentOS Linux-7:
+  python2_pkg: libvirt-python
+  python3_pkg: ~

--- a/libvirt/osmap.yaml
+++ b/libvirt/osmap.yaml
@@ -15,4 +15,5 @@ Fedora:
   python3_pkg: python3-libvirt
 
 CentOS:
-  python3_pkg: ~
+  python2_pkg: ~
+  python3_pkg: python3-libvirt

--- a/test/integration/share/libraries/libvirt.rb
+++ b/test/integration/share/libraries/libvirt.rb
@@ -16,7 +16,7 @@ class LibvirtResource < Inspec.resource(1)
   attr_reader :packages
 
   def initialize
-    @packages = build_packages
+    @packages = inspec.libvirt_packages.packages
   end
 
   def daemon_config_dir
@@ -33,76 +33,5 @@ class LibvirtResource < Inspec.resource(1)
 
   def daemon_config_file
     inspec.file(File.join(daemon_config_dir, 'libvirtd'))
-  end
-
-  def build_packages
-    # defaults.yaml
-    packages = build_default_packages
-
-    packages.merge!(build_overwrite_packages)
-  end
-
-  def build_overwrite_packages
-    # osfamily.yaml / osmap.yaml
-    case inspec.os[:family]
-    when 'debian'
-      build_debian_packages
-
-    when 'fedora'
-      build_fedora_packages
-
-    when 'suse'
-      build_suse_packages
-
-    else
-      {}
-    end
-  end
-
-  def build_default_packages
-    {
-      'libvirt' => ['libvirt'],
-      'qemu' => ['qemu-kvm'],
-      'extra' => ['libguestfs'],
-      'python' => if inspec.salt_minion.python3?
-                    ['libvirt-python3']
-                  else
-                    ['libvirt-python']
-                  end
-    }
-  end
-
-  def build_debian_packages
-    {
-      'libvirt' => ['libvirt-daemon-system'],
-      'extra' => %w[libguestfs0 libguestfs-tools gnutls-bin virt-top],
-      'python' => if inspec.salt_minion.python3?
-                    ['python3-libvirt']
-                  else
-                    ['python-libvirt']
-                  end
-    }
-  end
-
-  def build_fedora_packages
-    {
-      'python' => if inspec.salt_minion.python3?
-                    ['python3-libvirt']
-                  else
-                    ['python2-libvirt']
-                  end
-    }
-  end
-
-  def build_suse_packages
-    {
-      'libvirt' => ['libvirt-daemon-qemu'],
-      'extra' => ['libguestfs0'],
-      'python' => if inspec.salt_minion.python3?
-                    ['python3-libvirt-python']
-                  else
-                    ['python2-libvirt-python']
-                  end
-    }
   end
 end

--- a/test/integration/share/libraries/libvirt_packages.rb
+++ b/test/integration/share/libraries/libvirt_packages.rb
@@ -23,10 +23,11 @@ class LibvirtPackagesResource < Inspec.resource(1)
     # defaults.yaml
     packages = build_default_packages
 
-    packages.merge!(build_overwrite_packages)
+    packages.merge!(build_os_family_packages)
+    packages.merge!(build_os_name_packages)
   end
 
-  def build_overwrite_packages
+  def build_os_family_packages
     # osfamily.yaml / osmap.yaml
     case inspec.os[:family]
     when 'debian'
@@ -37,6 +38,17 @@ class LibvirtPackagesResource < Inspec.resource(1)
 
     when 'suse'
       build_suse_packages
+
+    else
+      {}
+    end
+  end
+
+  def build_os_name_packages
+    # osfamily.yaml / osmap.yaml
+    case inspec.os[:name]
+    when 'centos'
+      build_centos_packages
 
     else
       {}
@@ -88,5 +100,19 @@ class LibvirtPackagesResource < Inspec.resource(1)
                     ['python2-libvirt-python']
                   end
     }
+  end
+
+  def build_centos_packages
+    case inspec.os[:release]
+    when /^7/
+      if inspec.salt_minion.python3?
+        { 'python' => [] }
+      else
+        { 'python' => ['libvirt-python'] }
+      end
+    else
+      # Only python3 since CentOS 8
+      { 'python' => ['python3-libvirt'] }
+    end
   end
 end

--- a/test/integration/share/libraries/libvirt_packages.rb
+++ b/test/integration/share/libraries/libvirt_packages.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# libvirt.rb -- Libvirt InSpec resources
+# Author: Daniel Dehennin <daniel.dehennin@ac-dijon.fr>
+# Copyright (C) 2019 Pole de Competences Logiciels Libres <eole@ac-dijon.fr>
+
+class LibvirtPackagesResource < Inspec.resource(1)
+  name 'libvirt_packages'
+
+  supports platform_name: 'debian'
+  supports platform_name: 'ubuntu'
+  supports platform_name: 'centos'
+  supports platform_name: 'fedora'
+  supports platform_name: 'opensuse'
+
+  attr_reader :packages
+
+  def initialize
+    @packages = build_packages
+  end
+
+  def build_packages
+    # defaults.yaml
+    packages = build_default_packages
+
+    packages.merge!(build_overwrite_packages)
+  end
+
+  def build_overwrite_packages
+    # osfamily.yaml / osmap.yaml
+    case inspec.os[:family]
+    when 'debian'
+      build_debian_packages
+
+    when 'fedora'
+      build_fedora_packages
+
+    when 'suse'
+      build_suse_packages
+
+    else
+      {}
+    end
+  end
+
+  def build_default_packages
+    {
+      'libvirt' => ['libvirt'],
+      'qemu' => ['qemu-kvm'],
+      'extra' => ['libguestfs'],
+      'python' => if inspec.salt_minion.python3?
+                    ['libvirt-python3']
+                  else
+                    ['libvirt-python']
+                  end
+    }
+  end
+
+  def build_debian_packages
+    {
+      'libvirt' => ['libvirt-daemon-system'],
+      'extra' => %w[libguestfs0 libguestfs-tools gnutls-bin virt-top],
+      'python' => if inspec.salt_minion.python3?
+                    ['python3-libvirt']
+                  else
+                    ['python-libvirt']
+                  end
+    }
+  end
+
+  def build_fedora_packages
+    {
+      'python' => if inspec.salt_minion.python3?
+                    ['python3-libvirt']
+                  else
+                    ['python2-libvirt']
+                  end
+    }
+  end
+
+  def build_suse_packages
+    {
+      'libvirt' => ['libvirt-daemon-qemu'],
+      'extra' => ['libguestfs0'],
+      'python' => if inspec.salt_minion.python3?
+                    ['python3-libvirt-python']
+                  else
+                    ['python2-libvirt-python']
+                  end
+    }
+  end
+end


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Since CentOS 8, only python3 is available with packages names starting
by “python3-”.

* libvirt/osmap.yaml (CentOS): assume default CentOS version is 8 and above.

* libvirt/osfingermap.yaml (CentOS Linux-7): special casing older
  version 7.

* test/integration/share/libraries/libvirt.rb (LibvirtResource#build_centos_packages):
  distinguish python3 packages between CentOS 7 and 8.
  (LibvirtResource#build_os_family_packages): new name of
  “build_overwrite_packages” to make clean it's based on Inspec “os.family”.
  (LibvirtResource#build_os_name_packages): overwrite packages list
  based on Inspec “os.name”. Only for CentOS for now.
  (LibvirtResource#build_packages): merge per os family and per os
  name package overwrite lists.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

It support CentOS 8 which is full python3:

```
-----> Starting Test Kitchen (v2.3.4)
-----> Verifying <default-centos-8-2019-2-py3>...
       Loaded default 

Profile: libvirt formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:32773

  ✔  Libvirt service: verify running service
     ✔  Service libvirtd is expected to be enabled
     ✔  Service libvirtd is expected to be running
  ✔  Libvirt packages: verify installed packages
     ✔  System Package libvirt is expected to be installed
     ✔  System Package qemu-kvm is expected to be installed
     ✔  System Package libguestfs is expected to be installed
     ✔  System Package python3-libvirt is expected to be installed
  ✔  Libvirt read/write socket: should exist with proper permissions
     ✔  libvirt_socket_rw is expected to exist
     ✔  libvirt_socket_rw type is expected to eq :socket
     ✔  libvirt_socket_rw owner is expected to eq "root"
     ✔  libvirt_socket_rw group is expected to eq "root"
     ✔  libvirt_socket_rw mode is expected to cmp == "0770"
  ✔  Libvirt admin socket: should exist with proper permissions
     ✔  libvirt_socket_admin is expected to exist
     ✔  libvirt_socket_admin type is expected to eq :socket
     ✔  libvirt_socket_admin owner is expected to eq "root"
     ✔  libvirt_socket_admin group is expected to eq "root"
     ✔  libvirt_socket_admin mode is expected to cmp == "0700"
  ✔  Libvirt configuration: verify applied configuration
     ✔  File /etc/sysconfig/libvirtd is expected to exist
     ✔  File /etc/sysconfig/libvirtd content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  File /etc/libvirt/libvirtd.conf is expected to exist
     ✔  File /etc/libvirt/libvirtd.conf content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tls is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tcp is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tls_port is expected to eq "16514"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tcp_port is expected to eq "16509"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_addr is expected to eq "0.0.0.0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_group is expected to eq "root"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_ro_perms is expected to eq "0777"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_rw_perms is expected to eq "0770"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_ro is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_rw is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_tcp is expected to eq "none"
  ✔  Libvirt read only socket: should exist with proper permissions
     ✔  libvirt_socket_ro is expected to exist
     ✔  libvirt_socket_ro type is expected to eq :socket
     ✔  libvirt_socket_ro owner is expected to eq "root"
     ✔  libvirt_socket_ro group is expected to eq "root"
     ✔  libvirt_socket_ro mode is expected to cmp == "0777"


Profile: libvirt formula (share)
Version: (not specified)
Target:  ssh://kitchen@localhost:32773

     No tests executed.

Profile Summary: 6 successful controls, 0 control failures, 0 controls skipped
Test Summary: 36 successful, 0 failures, 0 skipped
       Finished verifying <default-centos-8-2019-2-py3> (0m6.08s).
-----> Test Kitchen is finished. (0m7.32s)
```

and CentOS 7 on python2

```
-----> Starting Test Kitchen (v2.3.4)
-----> Verifying <default-centos-7-2019-2-py2>...
       Loaded default 

Profile: libvirt formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:32772

  ✔  Libvirt service: verify running service
     ✔  Service libvirtd is expected to be enabled
     ✔  Service libvirtd is expected to be running
  ✔  Libvirt packages: verify installed packages
     ✔  System Package libvirt is expected to be installed
     ✔  System Package qemu-kvm is expected to be installed
     ✔  System Package libguestfs is expected to be installed
     ✔  System Package libvirt-python is expected to be installed
  ✔  Libvirt read/write socket: should exist with proper permissions
     ✔  libvirt_socket_rw is expected to exist
     ✔  libvirt_socket_rw type is expected to eq :socket
     ✔  libvirt_socket_rw owner is expected to eq "root"
     ✔  libvirt_socket_rw group is expected to eq "root"
     ✔  libvirt_socket_rw mode is expected to cmp == "0770"
  ✔  Libvirt admin socket: should exist with proper permissions
     ✔  libvirt_socket_admin is expected to exist
     ✔  libvirt_socket_admin type is expected to eq :socket
     ✔  libvirt_socket_admin owner is expected to eq "root"
     ✔  libvirt_socket_admin group is expected to eq "root"
     ✔  libvirt_socket_admin mode is expected to cmp == "0700"
  ✔  Libvirt configuration: verify applied configuration
     ✔  File /etc/sysconfig/libvirtd is expected to exist
     ✔  File /etc/sysconfig/libvirtd content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  File /etc/libvirt/libvirtd.conf is expected to exist
     ✔  File /etc/libvirt/libvirtd.conf content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tls is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tcp is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tls_port is expected to eq "16514"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tcp_port is expected to eq "16509"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_addr is expected to eq "0.0.0.0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_group is expected to eq "root"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_ro_perms is expected to eq "0777"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_rw_perms is expected to eq "0770"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_ro is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_rw is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_tcp is expected to eq "none"
  ✔  Libvirt read only socket: should exist with proper permissions
     ✔  libvirt_socket_ro is expected to exist
     ✔  libvirt_socket_ro type is expected to eq :socket
     ✔  libvirt_socket_ro owner is expected to eq "root"
     ✔  libvirt_socket_ro group is expected to eq "root"
     ✔  libvirt_socket_ro mode is expected to cmp == "0777"


Profile: libvirt formula (share)
Version: (not specified)
Target:  ssh://kitchen@localhost:32772

     No tests executed.

Profile Summary: 6 successful controls, 0 control failures, 0 controls skipped
Test Summary: 36 successful, 0 failures, 0 skipped
       Finished verifying <default-centos-7-2019-2-py2> (0m5.16s).
-----> Test Kitchen is finished. (0m6.52s)
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->
