### PR TITLE
feat(debian+ubuntu): improve support for older systems

### DIFF
--- a/libvirt/osfingermap.yaml
+++ b/libvirt/osfingermap.yaml
@@ -10,17 +10,6 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfingermap: {}
 ---
-## os: Debian
-# Squeeze
-Debian-6:
-  libvirt_pkg: libvirt-bin
-  libvirt_service: libvirt-bin
-
-# Jessie
-Debian-8:
-  libvirt_pkg: libvirt-bin
-
-
 ## os: Ubuntu
 # Trusty
 Ubuntu-14.04:

--- a/libvirt/osfingermap.yaml
+++ b/libvirt/osfingermap.yaml
@@ -11,10 +11,6 @@
 # osfingermap: {}
 ---
 ## os: Ubuntu
-# Trusty
-Ubuntu-14.04:
-  libvirt_pkg: libvirt-bin
-  libvirt_service: libvirt-bin
 # Xenial
 Ubuntu-16.04:
   libvirt_pkg: libvirt-bin

--- a/test/integration/share/libraries/libvirt.rb
+++ b/test/integration/share/libraries/libvirt.rb
@@ -32,6 +32,26 @@ class LibvirtResource < Inspec.resource(1)
   end
 
   def daemon_config_file
-    inspec.file(File.join(daemon_config_dir, 'libvirtd'))
+    inspec.file(File.join(daemon_config_dir, service_name))
+  end
+
+  def service_name
+    case inspec.os[:name]
+    when 'ubuntu'
+      service_name_ubuntu
+
+    else
+      'libvirtd'
+    end
+  end
+
+  def service_name_ubuntu
+    case inspec.os[:release]
+    when /^16/
+      'libvirt-bin'
+
+    else
+      'libvirtd'
+    end
   end
 end

--- a/test/integration/share/libraries/libvirt_packages.rb
+++ b/test/integration/share/libraries/libvirt_packages.rb
@@ -50,6 +50,9 @@ class LibvirtPackagesResource < Inspec.resource(1)
     when 'centos'
       build_centos_packages
 
+    when 'ubuntu'
+      build_ubuntu_packages
+
     else
       {}
     end
@@ -113,6 +116,15 @@ class LibvirtPackagesResource < Inspec.resource(1)
     else
       # Only python3 since CentOS 8
       { 'python' => ['python3-libvirt'] }
+    end
+  end
+
+  def build_ubuntu_packages
+    case inspec.os[:release]
+    when /^16/
+      { 'libvirt' => ['libvirt-bin'] }
+    else
+      {}
     end
   end
 end

--- a/test/integration/share/libraries/libvirt_socket_admin.rb
+++ b/test/integration/share/libraries/libvirt_socket_admin.rb
@@ -14,8 +14,24 @@ class LibvirtSocketAdminResource < Inspec.resource(1)
   supports platform_name: 'opensuse'
 
   def initialize
+    if skipped_platform?
+      raise Inspec::Exceptions::ResourceSkipped, 'No admin socket on this platform'
+    end
+
     @file = inspec.file('/var/run/libvirt/libvirt-admin-sock')
     @systemd_status = inspec.systemd_config('libvirtd-admin.socket')
+  end
+
+  def skipped_platform?
+    skipped_debian? || skipped_ubuntu?
+  end
+
+  def skipped_debian?
+    inspec.os[:name] == 'debian' && inspec.os[:release].match(/^8/)
+  end
+
+  def skipped_ubuntu?
+    inspec.os[:name] == 'ubuntu' && inspec.os[:release].match(/^16/)
   end
 
   def config_owner


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This PR add specificites for older Debian and Ubuntu systems:

- older Ubuntu use “libvirt-bin” as service name
- older Ubuntu use “libvirt-bin” as package name
- skip checks of admin socket on unsupported platforms
- remove support for very old Debian and Ubuntu versions

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

The tests pass on Debian 8 systems

```
-----> Starting Test Kitchen (v2.3.4)
-----> Verifying <default-debian-8-2017-7-py2>...
       Loaded default 

Profile: libvirt formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:32780

  ✔  Libvirt service: verify running service
     ✔  Service libvirtd is expected to be enabled
     ✔  Service libvirtd is expected to be running
  ✔  Libvirt packages: verify installed packages
     ✔  System Package libvirt-daemon-system is expected to be installed
     ✔  System Package qemu-kvm is expected to be installed
     ✔  System Package libguestfs0 is expected to be installed
     ✔  System Package libguestfs-tools is expected to be installed
     ✔  System Package gnutls-bin is expected to be installed
     ✔  System Package virt-top is expected to be installed
     ✔  System Package python-libvirt is expected to be installed
  ✔  Libvirt read/write socket: should exist with proper permissions
     ✔  libvirt_socket_rw is expected to exist
     ✔  libvirt_socket_rw type is expected to eq :socket
     ✔  libvirt_socket_rw owner is expected to eq "root"
     ✔  libvirt_socket_rw group is expected to eq "root"
     ✔  libvirt_socket_rw mode is expected to cmp == "0770"
  ↺  Libvirt admin socket: should exist with proper permissions
     ↺  No admin socket on this platform
  ✔  Libvirt configuration: verify applied configuration
     ✔  File /etc/default/libvirtd is expected to exist
     ✔  File /etc/default/libvirtd content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  File /etc/libvirt/libvirtd.conf is expected to exist
     ✔  File /etc/libvirt/libvirtd.conf content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tls is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tcp is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tls_port is expected to eq "16514"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tcp_port is expected to eq "16509"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_addr is expected to eq "0.0.0.0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_group is expected to eq "root"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_ro_perms is expected to eq "0777"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_rw_perms is expected to eq "0770"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_ro is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_rw is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_tcp is expected to eq "none"
  ✔  Libvirt read only socket: should exist with proper permissions
     ✔  libvirt_socket_ro is expected to exist
     ✔  libvirt_socket_ro type is expected to eq :socket
     ✔  libvirt_socket_ro owner is expected to eq "root"
     ✔  libvirt_socket_ro group is expected to eq "root"
     ✔  libvirt_socket_ro mode is expected to cmp == "0777"


Profile: libvirt formula (share)
Version: (not specified)
Target:  ssh://kitchen@localhost:32780

     No tests executed.

Profile Summary: 5 successful controls, 0 control failures, 1 control skipped
Test Summary: 34 successful, 0 failures, 1 skipped
       Finished verifying <default-debian-8-2017-7-py2> (0m3.21s).
-----> Test Kitchen is finished. (0m4.44s)
```

and Ubuntu 16.04 (Xenial)

```
-----> Starting Test Kitchen (v2.3.4)
-----> Verifying <default-ubuntu-1604-2018-3-py2>...
       Loaded default 

Profile: libvirt formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:32777

  ✔  Libvirt service: verify running service
     ✔  Service libvirtd is expected to be enabled
     ✔  Service libvirtd is expected to be running
  ✔  Libvirt packages: verify installed packages
     ✔  System Package libvirt-bin is expected to be installed
     ✔  System Package qemu-kvm is expected to be installed
     ✔  System Package libguestfs0 is expected to be installed
     ✔  System Package libguestfs-tools is expected to be installed
     ✔  System Package gnutls-bin is expected to be installed
     ✔  System Package virt-top is expected to be installed
     ✔  System Package python-libvirt is expected to be installed
  ✔  Libvirt read/write socket: should exist with proper permissions
     ✔  libvirt_socket_rw is expected to exist
     ✔  libvirt_socket_rw type is expected to eq :socket
     ✔  libvirt_socket_rw owner is expected to eq "root"
     ✔  libvirt_socket_rw group is expected to eq "root"
     ✔  libvirt_socket_rw mode is expected to cmp == "0770"
  ↺  Libvirt admin socket: should exist with proper permissions
     ↺  No admin socket on this platform
  ✔  Libvirt configuration: verify applied configuration
     ✔  File /etc/default/libvirt-bin is expected to exist
     ✔  File /etc/default/libvirt-bin content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  File /etc/libvirt/libvirtd.conf is expected to exist
     ✔  File /etc/libvirt/libvirtd.conf content is expected to match /This\sfile\sis\smanaged\sby\sSalt/
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tls is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_tcp is expected to eq "0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tls_port is expected to eq "16514"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf tcp_port is expected to eq "16509"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf listen_addr is expected to eq "0.0.0.0"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_group is expected to eq "root"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_ro_perms is expected to eq "0777"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf unix_sock_rw_perms is expected to eq "0770"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_ro is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_unix_rw is expected to eq "none"
     ✔  Parse Config File /etc/libvirt/libvirtd.conf auth_tcp is expected to eq "none"
  ✔  Libvirt read only socket: should exist with proper permissions
     ✔  libvirt_socket_ro is expected to exist
     ✔  libvirt_socket_ro type is expected to eq :socket
     ✔  libvirt_socket_ro owner is expected to eq "root"
     ✔  libvirt_socket_ro group is expected to eq "root"
     ✔  libvirt_socket_ro mode is expected to cmp == "0777"


Profile: libvirt formula (share)
Version: (not specified)
Target:  ssh://kitchen@localhost:32777

     No tests executed.

Profile Summary: 5 successful controls, 0 control failures, 1 control skipped
Test Summary: 34 successful, 0 failures, 1 skipped
       Finished verifying <default-ubuntu-1604-2018-3-py2> (0m3.30s).
-----> Test Kitchen is finished. (0m4.54s)
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


