### PR TITLE
fix(map): `path_join` can't be used to load YAML files on windows

### DIFF
--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -6,10 +6,10 @@
 {%- from tplroot ~ "/libsaltcli.jinja" import cli with context %}
 
 {#- Where to lookup parameters source files #}
-{%- set map_sources_dir = tplroot | path_join("parameters") %}
+{%- set map_sources_dir = tplroot ~ "/parameters" %}
 
 {#- Load defaults first to allow per formula default map.jinja configuration #}
-{%- set _defaults_filename = map_sources_dir | path_join("defaults.yaml") %}
+{%- set _defaults_filename = map_sources_dir ~ "/defaults.yaml" %}
 {%- do salt["log.debug"](
       "map.jinja: initialise parameters from "
       ~ _defaults_filename
@@ -144,9 +144,10 @@
 {%-     endif %}
 
 {%-     for map_value in map_values %}
-{%-       set yamlfile = map_sources_dir | path_join(
+{%-       set yamlfile = "{}/{}/{}.yaml".format(
+            map_sources_dir,
             map_source,
-            map_value ~ ".yaml",
+            map_value,
           ) %}
 {%-       do salt["log.debug"]("map.jinja: load parameters from file " ~ yamlfile) %}
 {%-       load_yaml as loaded_values %}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

It looks like `path_join` can't be used to build pathes for [`fileserver`](https://docs.saltstack.com/en/latest/ref/file_server/), it fails with `jinja2.exceptions.TemplateNotFound`.

* libvirt/map.jinja: replace all `path_join` with string concatenation.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

I created a `test-map.sls` with a minial `parameters/defaults.yaml` and execute it on a windows 10 minion version 3001:

``` sls
{#- Get the `tplroot` from `tpldir` #}
{%- set tplroot = tpldir.split('/')[0] %}
{%- from tplroot ~ '/map.jinja' import mapdata with context %}

test-map-jinja-on-windows:
  test.nop:
    - name: {{ mapdata | json }}
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Before:

```
    2020-07-24 07:33:16,410 [salt.state       :3968][CRITICAL][4864] Rendering SLS 'base:test-map' failed: Jinja error: test-map\parameters\defaults.yaml
    c:\salt\var\cache\salt\minion\files\base\test-map/map.jinja(17):
    ---
    [...]
    {%- set _defaults_filename = map_sources_dir | path_join("defaults.yaml") %}
    {%- do salt["log.debug"](
          "map.jinja: initialise parameters from "
          ~ _defaults_filename
        ) %}
    {%- import_yaml _defaults_filename as default_settings %}    <======================
    
    {#- List of sources to lookup for parameters #}
    {%- do salt["log.debug"]("map.jinja: lookup 'map_jinja' configuration sources") %}
    {#- Fallback to previously used grains plus minion `id` #}
    {%- set map_sources = [
    [...]
    ---
    Traceback (most recent call last):
      File "c:\salt\bin\lib\site-packages\salt-3001-py3.7.egg\salt\utils\templates.py", line 400, in render_jinja_tmpl
        output = template.render(**decoded_context)
      File "c:\salt\bin\lib\site-packages\jinja2\asyncsupport.py", line 76, in render
        return original_render(self, *args, **kwargs)
      File "c:\salt\bin\lib\site-packages\jinja2\environment.py", line 1008, in render
        return self.environment.handle_exception(exc_info, True)
      File "c:\salt\bin\lib\site-packages\jinja2\environment.py", line 780, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "c:\salt\bin\lib\site-packages\jinja2\_compat.py", line 37, in reraise
        raise value.with_traceback(tb)
      File "<template>", line 3, in top-level template code
      File "c:\salt\bin\lib\site-packages\jinja2\environment.py", line 1073, in make_module
        return TemplateModule(self, self.new_context(vars, shared, locals))
      File "c:\salt\bin\lib\site-packages\jinja2\environment.py", line 1152, in __init__
        body_stream = list(template.root_render_func(context))
      File "c:\salt\var\cache\salt\minion\files\base\test-map/map.jinja", line 17, in top-level template code
        {%- import_yaml _defaults_filename as default_settings %}
      File "c:\salt\bin\lib\site-packages\salt-3001-py3.7.egg\salt\utils\jinja.py", line 204, in get_source
        raise TemplateNotFound(template)
    jinja2.exceptions.TemplateNotFound: test-map\parameters\defaults.yaml
```

After:

```
          ID: test-map-jinja-on-windows
    Function: test.nop
      Result: True
     Comment: Success!
     Started: 07:49:32.738854
    Duration: 0.0 ms
     Changes:   
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


