### PR TITLE
fix: correct package names for debian 11, drop support for debian 9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,10 +144,10 @@ rubocop:
 # default-oraclelinux-7-tiamat-py3: {extends: '.test_instance'}
 # default-almalinux-8-tiamat-py3: {extends: '.test_instance'}
 # default-rockylinux-8-tiamat-py3: {extends: '.test_instance'}
-# default-debian-11-master-py3: {extends: '.test_instance'}
+default-debian-11-master-py3: {extends: '.test_instance'}
 default-debian-10-master-py3: {extends: '.test_instance'}
 # clean-debian-10-master-py3: {extends: '.test_instance'}
-default-debian-9-master-py3: {extends: '.test_instance'}
+# default-debian-9-master-py3: {extends: '.test_instance'}
 default-ubuntu-2204-master-py3: {extends: '.test_instance_failure_permitted'}
 default-ubuntu-2004-master-py3: {extends: '.test_instance'}
 default-ubuntu-1804-master-py3: {extends: '.test_instance'}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         always_run: true
         pass_filenames: false
   - repo: https://github.com/warpnet/salt-lint
-    rev: v0.8.0
+    rev: v0.9.2
     hooks:
       - id: salt-lint
         name: Check Salt files using salt-lint

--- a/libvirt/parameters/defaults.yaml
+++ b/libvirt/parameters/defaults.yaml
@@ -15,7 +15,7 @@ values:
   libvirt_pkg: libvirt
   qemu_pkg: qemu
   python2_pkg: libvirt-python
-  python3_pkg: libvirt-python3
+  python3_pkg: python3-libvirt
   libvirt_service: libvirtd
   libvirtd_config: /etc/libvirt/libvirtd.conf
   daemon_config_path: {}

--- a/libvirt/parameters/os/AlmaLinux.yaml
+++ b/libvirt/parameters/os/AlmaLinux.yaml
@@ -11,5 +11,4 @@
 ---
 values:
   python2_pkg: ~
-  python3_pkg: python3-libvirt
 ...

--- a/libvirt/parameters/os/CentOS.yaml
+++ b/libvirt/parameters/os/CentOS.yaml
@@ -11,5 +11,4 @@
 ---
 values:
   python2_pkg: ~
-  python3_pkg: python3-libvirt
 ...

--- a/libvirt/parameters/os/Fedora.yaml
+++ b/libvirt/parameters/os/Fedora.yaml
@@ -11,5 +11,4 @@
 ---
 values:
   python2_pkg: python2-libvirt
-  python3_pkg: python3-libvirt
 ...

--- a/libvirt/parameters/os/Rocky.yaml
+++ b/libvirt/parameters/os/Rocky.yaml
@@ -11,5 +11,4 @@
 ---
 values:
   python2_pkg: ~
-  python3_pkg: python3-libvirt
 ...

--- a/libvirt/parameters/os_family/Debian.yaml
+++ b/libvirt/parameters/os_family/Debian.yaml
@@ -12,13 +12,11 @@
 values:
   libvirt_pkg: libvirt-daemon-system
   libvirt_service: libvirtd
-  qemu_pkg: qemu-kvm
+  qemu_pkg: qemu-system-x86
   python2_pkg: python-libvirt
-  python3_pkg: python3-libvirt
   extra_pkgs:
     - libguestfs0
     - libguestfs-tools
     - gnutls-bin
-    - virt-top
   daemon_config_path: /etc/default
 ...

--- a/libvirt/parameters/osfinger/Debian-9.yaml
+++ b/libvirt/parameters/osfinger/Debian-9.yaml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 #
-# Setup variables specific to salt['config.get']('osfinger') == Ubuntu-22.04.
+# Setup variables specific to salt['config.get']('osfinger') == Debian-9.
 # You just need to add the key:values for this `osfinger` that differ
 # from `defaults.yaml`.
 #
@@ -10,5 +10,7 @@
 # values: {}
 ---
 values:
-  qemu_pkg: qemu-system-x86
+  extra_pkgs:
+    - gnutls-bin
+  qemu_pkg: qemu-kvm
 ...

--- a/libvirt/parameters/osfinger/Ubuntu-18.04.yaml
+++ b/libvirt/parameters/osfinger/Ubuntu-18.04.yaml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 #
-# Setup variables specific to salt['config.get']('osfinger') == Ubuntu-16.04.
+# Setup variables specific to salt['config.get']('osfinger') == Ubuntu-18.04.
 # You just need to add the key:values for this `osfinger` that differ
 # from `defaults.yaml`.
 #
@@ -10,6 +10,5 @@
 # values: {}
 ---
 values:
-  libvirt_pkg: libvirt-bin
-  libvirt_service: libvirt-bin
+  qemu_pkg: qemu-kvm
 ...

--- a/libvirt/parameters/osfinger/Ubuntu-20.04.yaml
+++ b/libvirt/parameters/osfinger/Ubuntu-20.04.yaml
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+#
+# Setup variables specific to salt['config.get']('osfinger') == Ubuntu-20.04.
+# You just need to add the key:values for this `osfinger` that differ
+# from `defaults.yaml`.
+#
+# If you do not need to provide defaults via the `osfinger` config,
+# you can remove this file or provide at least an empty dict, e.g.
+# values: {}
+---
+values:
+  qemu_pkg: qemu-kvm
+...

--- a/test/integration/share/libraries/libvirt_packages.rb
+++ b/test/integration/share/libraries/libvirt_packages.rb
@@ -78,7 +78,8 @@ class LibvirtPackagesResource < Inspec.resource(1)
   def build_debian_packages
     {
       'libvirt' => ['libvirt-daemon-system'],
-      'extra' => %w[libguestfs0 libguestfs-tools gnutls-bin virt-top],
+      'qemu' => ['qemu-system-x86'],
+      'extra' => %w[libguestfs0 libguestfs-tools gnutls-bin],
       'python' => if inspec.salt_minion.python3?
                     ['python3-libvirt']
                   else
@@ -134,8 +135,6 @@ class LibvirtPackagesResource < Inspec.resource(1)
 
   def build_ubuntu_packages
     case inspec.system.platform[:release]
-    when /^22/
-      { 'qemu' => ['qemu-system-x86'] }
     when /^16/
       { 'libvirt' => ['libvirt-bin'] }
     else


### PR DESCRIPTION
fix: correct package names for debian 11, drop support for debian 9

ref #89 

also changed map data to switch defaults to more recent packages, and only overwrite them on some older distro releases

and removed the virt-top package, which exists on some Debian / Ubuntu releases but not on others. not required for libvirt functionality anyway, since it's only a top-like utility.

as a bonus, this also fixes CentOS 8, which was broken in the CI without this PR.

